### PR TITLE
Make it fullsized

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -12,6 +12,21 @@ html {
     color: #fff;
     font-family: "Source Sans Pro", Helvetica, Arial, sans-serif;
 }
+
+html, body, #root, .container {
+    height: 100%;
+}
+
+#root > div {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+}
+
+.navBar + div {
+       overflow: hidden;
+}
+
 .navBar {
     display: flex;
     justify-content: space-between;
@@ -50,25 +65,24 @@ td {
     text-align: left;
 }
 #container {
+    height: 100%;
     display: flex;
     flex-direction: row;
 }
 #dragElements {
     background: #111;
-    width: 40vw;
-    height: 80vh;
-    overflow: scroll;
+    overflow-y: scroll;
+    flex: 1;
 }
 #dropTarget {
     background: #333;
-    width: 40vw;
-    height: 80vh;
+    overflow-y: scroll;
+    flex: 1;
 }
 .formElem {
     text-align: center;
     margin: 0.7vw 2.5vw;
     color: #fff;
-    width: 35vw;
     font-size: 1.5em;
     background: purple;
 }


### PR DESCRIPTION
If I haven't forgotten to include some rule, this should make the interface use all screen. I can't find the correct file (haven't worked in React), but the submit button should be moved to `.navBar` or just overlay it absoloutely on the corner of `#dropTarget`.

I also suggest to make the dom less nested, it's quite hard to style sizings if the elements are 7 levels deep and should all be pretty much the same size. I would normally lay `.navBar`, `#dragElements` and `#dropTarget` directly in the body and position them using grid. Can React have body as the root? If React needs a wrapper and you want to use flex, you could still avoid the wrapper inside `#root` and the one around `.container`?

The `.formElem`'s `margin: .7vw 2.5vw;` is a bit suspicious. Do you really want smaller gap on the smaller screens? It makes it harder to hit the correct target.